### PR TITLE
ref(calendar): adjust initialization of selectedMonth with `initialDateSelected` value if not null

### DIFF
--- a/lib/controllers/clean_calendar_controller.dart
+++ b/lib/controllers/clean_calendar_controller.dart
@@ -123,7 +123,8 @@ class CleanCalendarController extends ChangeNotifier {
 
     years.sort();
 
-    selectedMonth = months[DateTime.now().month - 1];
+    selectedMonth =
+        months[(initialDateSelected?.month ?? DateTime.now().month) - 1];
     selectedYear = DateTime(selectedMonth.year);
 
     if (initialDateSelected != null &&


### PR DESCRIPTION
For calendar summary test purposes